### PR TITLE
add "from_set" option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    env_parser (0.2.0)
+    env_parser (0.3.0)
       activesupport (>= 5.0.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset: 250 ## => 250
 ## Note that "if_unset" values are used as-is, with no type conversion.
 ##
 EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset: 'oof!' ## => 'oof!'
+
+## You can also restrict the set of allowed values.
+## (Sometimes setting the type alone is a bit too open-ended.)
+##
+EnvParser.parse :API_TO_USE, as: :symbol, from_set: %i[internal external]
+EnvParser.parse :SOME_CUSTOM_NETWORK_PORT, as: :integer, from_set: (1..65535), if_unset: 80
+
+## And if the value is not allowed...
+##
+EnvParser.parse :SOME_NEGATIVE_NUMBER, as: :integer, from_set: (1..5) ## => raises EnvParser::ValueNotAllowed
 ```
 
 ---
@@ -77,7 +87,6 @@ Note JSON is parsed using *quirks-mode* (meaning 'true', '25', and 'null' are al
 ## Feature Roadmap / Future Development
 
 Additional features/options coming in the future:
-- A `:from_set` option to restrict acceptable values to those on a given list.
 - An `EnvParser.load` method that will not only parse the given value, but will set a constant, easily converting environment variables into constants in your code.
 - An `EnvParser.load_all` method to shortcut multiple `.load` calls.
 - A means to **optionally** bind `#parse`, `#load`, and `#load_all` methods onto `ENV` itself (not all hashes!). Because `ENV.parse ...` reads better than `EnvParser.parse ...`.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ timeout_ms = EnvParser.parse ENV['TIMEOUT_MS'], as: :integer
 ## (i.e. passing in `ENV['X']` is equivalent to passing in `:X`)
 ##
 timeout_ms = EnvParser.parse :TIMEOUT_MS, as: :integer
+
+## If the ENV variable you want is unset (`nil`) or blank (`''`),
+## the return value is a sensible default for the given "as" type.
+## Sometimes you want a non-trivial default (not just 0, '', etc), however.
+##
+EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer ## => 0
+EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset: 250 ## => 250
+
+## Note that "if_unset" values are used as-is, with no type conversion.
+##
+EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset: 'oof!' ## => 'oof!'
 ```
 
 ---

--- a/docs/EnvParser.html
+++ b/docs/EnvParser.html
@@ -120,7 +120,7 @@ different data types.</p>
       <dt id="VERSION-constant" class="">VERSION =
         
       </dt>
-      <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>0.1.0</span><span class='tstring_end'>&#39;</span></span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
+      <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>0.2.0</span><span class='tstring_end'>&#39;</span></span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
     
   </dl>
 
@@ -352,7 +352,7 @@ the “as” type.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Nov 29 06:44:05 2017 by
+  Generated on Wed Nov 29 17:00:46 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/EnvParser.html
+++ b/docs/EnvParser.html
@@ -113,14 +113,24 @@ different data types.</p>
 <div class="tags">
   
 
-</div>
+</div><h2>Defined Under Namespace</h2>
+<p class="children">
+  
+    
+  
+    
+      <strong class="classes">Classes:</strong> <span class='object_link'><a href="EnvParser/ValueNotAllowed.html" title="EnvParser::ValueNotAllowed (class)">ValueNotAllowed</a></span>
+    
+  
+</p>
+
   <h2>Constant Summary</h2>
   <dl class="constants">
     
       <dt id="VERSION-constant" class="">VERSION =
         
       </dt>
-      <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>0.2.0</span><span class='tstring_end'>&#39;</span></span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
+      <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>0.3.0</span><span class='tstring_end'>&#39;</span></span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
     
   </dl>
 
@@ -265,6 +275,9 @@ source String to the requested type. Valid “as” types are:</p>
 </li><li>
 <p><code>:hash</code></p>
 </li></ul>
+
+<p>If no “as” option is given (or the “as” value given is not on the above
+list), an ArgumentError exception is raised.</p>
 </div>
           
         </li>
@@ -277,11 +290,36 @@ source String to the requested type. Valid “as” types are:</p>
           </span>
           
             &mdash; <div class='inline'>
-<p>Specifies the default value to return if the given “value” is either nil or
-an empty String (&#39;&#39;). Any “if_unset” value given will be returned
-as-is, with no type conversion or other change having been made. If
-unspecified, the “default” value for nil/&#39;&#39; input will depend on
-the “as” type.</p>
+<p>Specifies the default value to return if the given “value” is either unset
+(<code>nil</code>) or blank (<code>&#39;&#39;</code>). Any “if_unset” value
+given will be returned as-is, with no type conversion or other change
+having been made. If unspecified, the “default” value for
+<code>nil</code>/<code>&#39;&#39;</code> input will depend on the “as”
+type.</p>
+</div>
+          
+        </li>
+      
+        <li>
+          <span class="name">from_set</span>
+          <span class="type">(<tt>Array</tt>, <tt>Range</tt>)</span>
+          <span class="default">
+            
+          </span>
+          
+            &mdash; <div class='inline'>
+<p>Gives a limited set of allowed values (after type conversion). If, after
+parsing, the final value is not included in the “from_set” list/range, an
+EnvParser::ValueNotAllowed exception is raised.</p>
+
+<p>Note that if the “if_unset” option is given and the value to parse is
+<code>nil</code>/<code>&#39;&#39;</code>, the “if_unset” value will be
+returned, even if it is not part of the “from_set” list/range.</p>
+
+<p>Also note that, due to the nature of the lookup, the “from_set” option is
+only available for scalar values (i.e. not arrays, hashes, or other
+enumerables). An attempt to use the “from_set” option with a non-scalar
+value will raise an ArgumentError exception.</p>
 </div>
           
         </li>
@@ -289,6 +327,19 @@ the “as” type.</p>
     </ul>
   
 
+<p class="tag_title">Raises:</p>
+<ul class="raise">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>ArgumentError</tt>, <tt><span class='object_link'><a href="EnvParser/ValueNotAllowed.html" title="EnvParser::ValueNotAllowed (class)">EnvParser::ValueNotAllowed</a></span></tt>)</span>
+      
+      
+      
+    </li>
+  
+</ul>
 
 </div><table class="source_code">
   <tr>
@@ -296,51 +347,51 @@ the “as” type.</p>
       <pre class="lines">
 
 
-33
-34
-35
-36
-37
-38
-39
-40
-41
-42
-43
-44
-45
-46
-47
-48
-49
-50
-51
-52
-53</pre>
+55
+56
+57
+58
+59
+60
+61
+62
+63
+64
+65
+66
+67
+68
+69
+70
+71
+72
+73
+74
+75</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/env_parser.rb', line 33</span>
+      <pre class="code"><span class="info file"># File 'lib/env_parser.rb', line 55</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='comma'>,</span> <span class='id identifier rubyid_options'>options</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_value'>value</span> <span class='op'>=</span> <span class='kw'>if</span> <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_is_a?'>is_a?</span> <span class='const'>Symbol</span>
-            <span class='const'>ENV</span><span class='lbracket'>[</span><span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span><span class='rbracket'>]</span>
-          <span class='kw'>else</span>
-            <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span>
-          <span class='kw'>end</span>
+  <span class='id identifier rubyid_value'>value</span> <span class='op'>=</span> <span class='const'>ENV</span><span class='lbracket'>[</span><span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span><span class='rbracket'>]</span> <span class='kw'>if</span> <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_is_a?'>is_a?</span> <span class='const'>Symbol</span>
+  <span class='id identifier rubyid_value'>value</span> <span class='op'>=</span> <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span>
 
   <span class='kw'>return</span> <span class='id identifier rubyid_options'>options</span><span class='lbracket'>[</span><span class='symbol'>:if_unset</span><span class='rbracket'>]</span> <span class='kw'>if</span> <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_blank?'>blank?</span> <span class='op'>&amp;&amp;</span> <span class='id identifier rubyid_options'>options</span><span class='period'>.</span><span class='id identifier rubyid_key?'>key?</span><span class='lparen'>(</span><span class='symbol'>:if_unset</span><span class='rparen'>)</span>
 
-  <span class='kw'>case</span> <span class='id identifier rubyid_options'>options</span><span class='lbracket'>[</span><span class='symbol'>:as</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_to_sym'>to_sym</span>
-  <span class='kw'>when</span> <span class='symbol'>:string</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_string'>parse_string</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
-  <span class='kw'>when</span> <span class='symbol'>:symbol</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_symbol'>parse_symbol</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
-  <span class='kw'>when</span> <span class='symbol'>:boolean</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_boolean'>parse_boolean</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
-  <span class='kw'>when</span> <span class='symbol'>:int</span><span class='comma'>,</span> <span class='symbol'>:integer</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_integer'>parse_integer</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
-  <span class='kw'>when</span> <span class='symbol'>:float</span><span class='comma'>,</span> <span class='symbol'>:decimal</span><span class='comma'>,</span> <span class='symbol'>:number</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_float'>parse_float</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
-  <span class='kw'>when</span> <span class='symbol'>:json</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_json'>parse_json</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
-  <span class='kw'>when</span> <span class='symbol'>:array</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_array'>parse_array</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
-  <span class='kw'>when</span> <span class='symbol'>:hash</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_hash'>parse_hash</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
-  <span class='kw'>else</span> <span class='id identifier rubyid_raise'>raise</span> <span class='const'>ArgumentError</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>invalid `as` parameter: </span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_options'>options</span><span class='lbracket'>[</span><span class='symbol'>:as</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_inspect'>inspect</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span>
-  <span class='kw'>end</span>
+  <span class='id identifier rubyid_value'>value</span> <span class='op'>=</span> <span class='kw'>case</span> <span class='id identifier rubyid_options'>options</span><span class='lbracket'>[</span><span class='symbol'>:as</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_to_sym'>to_sym</span>
+          <span class='kw'>when</span> <span class='symbol'>:string</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_string'>parse_string</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
+          <span class='kw'>when</span> <span class='symbol'>:symbol</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_symbol'>parse_symbol</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
+          <span class='kw'>when</span> <span class='symbol'>:boolean</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_boolean'>parse_boolean</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
+          <span class='kw'>when</span> <span class='symbol'>:int</span><span class='comma'>,</span> <span class='symbol'>:integer</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_integer'>parse_integer</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
+          <span class='kw'>when</span> <span class='symbol'>:float</span><span class='comma'>,</span> <span class='symbol'>:decimal</span><span class='comma'>,</span> <span class='symbol'>:number</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_float'>parse_float</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
+          <span class='kw'>when</span> <span class='symbol'>:json</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_json'>parse_json</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
+          <span class='kw'>when</span> <span class='symbol'>:array</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_array'>parse_array</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
+          <span class='kw'>when</span> <span class='symbol'>:hash</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_hash'>parse_hash</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
+          <span class='kw'>else</span> <span class='id identifier rubyid_raise'>raise</span> <span class='const'>ArgumentError</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>invalid `as` parameter: </span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_options'>options</span><span class='lbracket'>[</span><span class='symbol'>:as</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_inspect'>inspect</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span>
+          <span class='kw'>end</span>
+
+  <span class='id identifier rubyid_check_for_set_inclusion'>check_for_set_inclusion</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='comma'>,</span> <span class='label'>set:</span> <span class='id identifier rubyid_options'>options</span><span class='lbracket'>[</span><span class='symbol'>:from_set</span><span class='rbracket'>]</span><span class='rparen'>)</span> <span class='kw'>if</span> <span class='id identifier rubyid_options'>options</span><span class='period'>.</span><span class='id identifier rubyid_key?'>key?</span><span class='lparen'>(</span><span class='symbol'>:from_set</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_value'>value</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -352,7 +403,7 @@ the “as” type.</p>
 </div>
 
       <div id="footer">
-  Generated on Wed Nov 29 17:00:46 2017 by
+  Generated on Wed Nov 29 18:34:06 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/EnvParser/ValueNotAllowed.html
+++ b/docs/EnvParser/ValueNotAllowed.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>
+  Exception: EnvParser::ValueNotAllowed
+  
+    &mdash; Documentation by YARD 0.9.11
+  
+</title>
+
+  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+
+  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+
+<script type="text/javascript" charset="utf-8">
+  pathId = "EnvParser::ValueNotAllowed";
+  relpath = '../';
+</script>
+
+
+  <script type="text/javascript" charset="utf-8" src="../js/jquery.js"></script>
+
+  <script type="text/javascript" charset="utf-8" src="../js/app.js"></script>
+
+
+  </head>
+  <body>
+    <div class="nav_wrap">
+      <iframe id="nav" src="../class_list.html?1"></iframe>
+      <div id="resizer"></div>
+    </div>
+
+    <div id="main" tabindex="-1">
+      <div id="header">
+        <div id="menu">
+  
+    <a href="../_index.html">Index (V)</a> &raquo;
+    <span class='title'><span class='object_link'><a href="../EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span>
+     &raquo; 
+    <span class="title">ValueNotAllowed</span>
+  
+</div>
+
+        <div id="search">
+  
+    <a class="full_list_link" id="class_list_link"
+        href="../class_list.html">
+
+        <svg width="24" height="24">
+          <rect x="0" y="4" width="24" height="4" rx="1" ry="1"></rect>
+          <rect x="0" y="12" width="24" height="4" rx="1" ry="1"></rect>
+          <rect x="0" y="20" width="24" height="4" rx="1" ry="1"></rect>
+        </svg>
+    </a>
+  
+</div>
+        <div class="clear"></div>
+      </div>
+
+      <div id="content"><h1>Exception: EnvParser::ValueNotAllowed
+  
+  
+  
+</h1>
+<div class="box_info">
+  
+  <dl>
+    <dt>Inherits:</dt>
+    <dd>
+      <span class="inheritName">StandardError</span>
+      
+        <ul class="fullTree">
+          <li>Object</li>
+          
+            <li class="next">StandardError</li>
+          
+            <li class="next">EnvParser::ValueNotAllowed</li>
+          
+        </ul>
+        <a href="#" class="inheritanceTree">show all</a>
+      
+    </dd>
+  </dl>
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+  <dl>
+    <dt>Defined in:</dt>
+    <dd>lib/env_parser.rb</dd>
+  </dl>
+  
+</div>
+
+<h2>Overview</h2><div class="docstring">
+  <div class="discussion">
+    
+<p>Exception class used to indicate parsed values not allowed per a “from_set”
+option.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div>
+
+
+
+
+
+
+
+  
+
+</div>
+
+      <div id="footer">
+  Generated on Wed Nov 29 18:34:06 2017 by
+  <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
+  0.9.11 (ruby-2.4.2).
+</div>
+
+    </div>
+  </body>
+</html>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -97,7 +97,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Nov 29 06:44:04 2017 by
+  Generated on Wed Nov 29 17:00:45 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -88,6 +88,21 @@
           </ul>
         </ul>
       
+        
+        <ul id="alpha_V" class="alpha">
+          <li class="letter">V</li>
+          <ul>
+            
+              <li>
+                <span class='object_link'><a href="EnvParser/ValueNotAllowed.html" title="EnvParser::ValueNotAllowed (class)">ValueNotAllowed</a></span>
+                
+                  <small>(EnvParser)</small>
+                
+              </li>
+            
+          </ul>
+        </ul>
+      
     </td>
   </tr>
 </table>
@@ -97,7 +112,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Nov 29 17:00:45 2017 by
+  Generated on Wed Nov 29 18:34:06 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/class_list.html
+++ b/docs/class_list.html
@@ -43,7 +43,7 @@
 
       <ul id="full_list" class="class">
         <li id="object_" class="odd"><div class="item" style="padding-left:30px"><span class='object_link'><a href="top-level-namespace.html" title="Top Level Namespace (root)">Top Level Namespace</a></span></div></li>
-<li id='object_EnvParser' class='even'><div class='item' style='padding-left:30px'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span> &lt; Object<small class='search_info'>Top Level Namespace</small></div></li>
+<li id='object_EnvParser' class='even'><div class='item' style='padding-left:30px'><a class='toggle'></a> <span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span> &lt; Object<small class='search_info'>Top Level Namespace</small></div><ul><li id='object_EnvParser::ValueNotAllowed' class='collapsed odd'><div class='item' style='padding-left:45px'><span class='object_link'><a href="EnvParser/ValueNotAllowed.html" title="EnvParser::ValueNotAllowed (class)">ValueNotAllowed</a></span> &lt; StandardError<small class='search_info'>EnvParser</small></div></li></ul></li>
 
       </ul>
     </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -110,7 +110,22 @@ simple.</p>
 
 <h2 id="label-28i.e.+passing+in+ENV-5B-27X-27-5D+is+equivalent+to+passing+in+-3AX-29">(i.e. passing in <code>ENV['X']</code> is equivalent to passing in <code>:X</code>)</h2>
 
-<p>## timeout_ms = EnvParser.parse :TIMEOUT_MS, as: :integer “`</p>
+<p>## timeout_ms = EnvParser.parse :TIMEOUT_MS, as: :integer</p>
+
+<h2 id="label-If+the+ENV+variable+you+want+is+unset+-28nil-29+or+blank+-28-27-27-29-2C">If the ENV variable you want is unset (<code>nil</code>) or blank (<code>&#39;&#39;</code>),</h2>
+
+<h2 id="label-the+return+value+is+a+sensible+default+for+the+given+-22as-22+type.">the return value is a sensible default for the given “as” type.</h2>
+
+<h2 id="label-Sometimes+you+want+a+non-trivial+default+-28not+just+0-2C+-27-27-2C+etc-29-2C+however.">Sometimes you want a non-trivial default (not just 0, &#39;&#39;, etc), however.</h2>
+
+<p>## EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer ## =&gt; 0
+EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset: 250 ## =&gt;
+250</p>
+
+<h2 id="label-Note+that+-22if_unset-22+values+are+used+as-is-2C+with+no+type+conversion.">Note that “if_unset” values are used as-is, with no type conversion.</h2>
+
+<p>## EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset:
+&#39;oof!&#39; ## =&gt; &#39;oof!&#39; “`</p>
 <hr>
 
 <p>The named <code>:as</code> value is required. Allowed values are:</p>
@@ -131,8 +146,7 @@ the repo docs</a> for the full EnvParser documentation.</p>
 
 <h2 id="label-Feature+Roadmap+-2F+Future+Development">Feature Roadmap / Future Development</h2>
 
-<p>Additional features/options coming in the future: - An
-<code>:if_unset</code> option to more easily set default values. - A
+<p>Additional features/options coming in the future: - A
 <code>:from_set</code> option to restrict acceptable values to those on a
 given list. - An <code>EnvParser.load</code> method that will not only
 parse the given value, but will set a constant, easily converting
@@ -172,7 +186,7 @@ href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Wed Nov 29 06:44:05 2017 by
+  Generated on Wed Nov 29 17:00:46 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -125,7 +125,20 @@ EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset: 250 ## =&gt;
 <h2 id="label-Note+that+-22if_unset-22+values+are+used+as-is-2C+with+no+type+conversion.">Note that “if_unset” values are used as-is, with no type conversion.</h2>
 
 <p>## EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset:
-&#39;oof!&#39; ## =&gt; &#39;oof!&#39; “`</p>
+&#39;oof!&#39; ## =&gt; &#39;oof!&#39;</p>
+
+<h2 id="label-You+can+also+restrict+the+set+of+allowed+values.">You can also restrict the set of allowed values.</h2>
+
+<h2 id="label-28Sometimes+setting+the+type+alone+is+a+bit+too+open-ended.-29">(Sometimes setting the type alone is a bit too open-ended.)</h2>
+
+<p>## EnvParser.parse :API_TO_USE, as: :symbol, from_set: %i[internal
+external] EnvParser.parse :SOME_CUSTOM_NETWORK_PORT, as: :integer,
+from_set: (1..65535), if_unset: 80</p>
+
+<h2 id="label-And+if+the+value+is+not+allowed...">And if the value is not allowed…</h2>
+
+<p>## EnvParser.parse :SOME_NEGATIVE_NUMBER, as: :integer, from_set: (1..5) ##
+=&gt; raises EnvParser::ValueNotAllowed “`</p>
 <hr>
 
 <p>The named <code>:as</code> value is required. Allowed values are:</p>
@@ -146,16 +159,15 @@ the repo docs</a> for the full EnvParser documentation.</p>
 
 <h2 id="label-Feature+Roadmap+-2F+Future+Development">Feature Roadmap / Future Development</h2>
 
-<p>Additional features/options coming in the future: - A
-<code>:from_set</code> option to restrict acceptable values to those on a
-given list. - An <code>EnvParser.load</code> method that will not only
-parse the given value, but will set a constant, easily converting
-environment variables into constants in your code. - An
-<code>EnvParser.load_all</code> method to shortcut multiple
-<code>.load</code> calls. - A means to <strong>optionally</strong> bind
-<code>#parse</code>, <code>#load</code>, and <code>#load_all</code> methods
-onto <code>ENV</code> itself (not all hashes!). Because <code>ENV.parse
-...</code> reads better than <code>EnvParser.parse ...</code>. - … ?</p>
+<p>Additional features/options coming in the future: - An
+<code>EnvParser.load</code> method that will not only parse the given
+value, but will set a constant, easily converting environment variables
+into constants in your code. - An <code>EnvParser.load_all</code> method to
+shortcut multiple <code>.load</code> calls. - A means to
+<strong>optionally</strong> bind <code>#parse</code>, <code>#load</code>,
+and <code>#load_all</code> methods onto <code>ENV</code> itself (not all
+hashes!). Because <code>ENV.parse ...</code> reads better than
+<code>EnvParser.parse ...</code>. - … ?</p>
 
 <h2 id="label-Contribution+-2F+Development">Contribution / Development</h2>
 
@@ -186,7 +198,7 @@ href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Wed Nov 29 17:00:46 2017 by
+  Generated on Wed Nov 29 18:34:06 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -125,7 +125,20 @@ EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset: 250 ## =&gt;
 <h2 id="label-Note+that+-22if_unset-22+values+are+used+as-is-2C+with+no+type+conversion.">Note that “if_unset” values are used as-is, with no type conversion.</h2>
 
 <p>## EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset:
-&#39;oof!&#39; ## =&gt; &#39;oof!&#39; “`</p>
+&#39;oof!&#39; ## =&gt; &#39;oof!&#39;</p>
+
+<h2 id="label-You+can+also+restrict+the+set+of+allowed+values.">You can also restrict the set of allowed values.</h2>
+
+<h2 id="label-28Sometimes+setting+the+type+alone+is+a+bit+too+open-ended.-29">(Sometimes setting the type alone is a bit too open-ended.)</h2>
+
+<p>## EnvParser.parse :API_TO_USE, as: :symbol, from_set: %i[internal
+external] EnvParser.parse :SOME_CUSTOM_NETWORK_PORT, as: :integer,
+from_set: (1..65535), if_unset: 80</p>
+
+<h2 id="label-And+if+the+value+is+not+allowed...">And if the value is not allowed…</h2>
+
+<p>## EnvParser.parse :SOME_NEGATIVE_NUMBER, as: :integer, from_set: (1..5) ##
+=&gt; raises EnvParser::ValueNotAllowed “`</p>
 <hr>
 
 <p>The named <code>:as</code> value is required. Allowed values are:</p>
@@ -146,16 +159,15 @@ the repo docs</a> for the full EnvParser documentation.</p>
 
 <h2 id="label-Feature+Roadmap+-2F+Future+Development">Feature Roadmap / Future Development</h2>
 
-<p>Additional features/options coming in the future: - A
-<code>:from_set</code> option to restrict acceptable values to those on a
-given list. - An <code>EnvParser.load</code> method that will not only
-parse the given value, but will set a constant, easily converting
-environment variables into constants in your code. - An
-<code>EnvParser.load_all</code> method to shortcut multiple
-<code>.load</code> calls. - A means to <strong>optionally</strong> bind
-<code>#parse</code>, <code>#load</code>, and <code>#load_all</code> methods
-onto <code>ENV</code> itself (not all hashes!). Because <code>ENV.parse
-...</code> reads better than <code>EnvParser.parse ...</code>. - … ?</p>
+<p>Additional features/options coming in the future: - An
+<code>EnvParser.load</code> method that will not only parse the given
+value, but will set a constant, easily converting environment variables
+into constants in your code. - An <code>EnvParser.load_all</code> method to
+shortcut multiple <code>.load</code> calls. - A means to
+<strong>optionally</strong> bind <code>#parse</code>, <code>#load</code>,
+and <code>#load_all</code> methods onto <code>ENV</code> itself (not all
+hashes!). Because <code>ENV.parse ...</code> reads better than
+<code>EnvParser.parse ...</code>. - … ?</p>
 
 <h2 id="label-Contribution+-2F+Development">Contribution / Development</h2>
 
@@ -186,7 +198,7 @@ href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Wed Nov 29 17:00:45 2017 by
+  Generated on Wed Nov 29 18:34:06 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -110,7 +110,22 @@ simple.</p>
 
 <h2 id="label-28i.e.+passing+in+ENV-5B-27X-27-5D+is+equivalent+to+passing+in+-3AX-29">(i.e. passing in <code>ENV['X']</code> is equivalent to passing in <code>:X</code>)</h2>
 
-<p>## timeout_ms = EnvParser.parse :TIMEOUT_MS, as: :integer “`</p>
+<p>## timeout_ms = EnvParser.parse :TIMEOUT_MS, as: :integer</p>
+
+<h2 id="label-If+the+ENV+variable+you+want+is+unset+-28nil-29+or+blank+-28-27-27-29-2C">If the ENV variable you want is unset (<code>nil</code>) or blank (<code>&#39;&#39;</code>),</h2>
+
+<h2 id="label-the+return+value+is+a+sensible+default+for+the+given+-22as-22+type.">the return value is a sensible default for the given “as” type.</h2>
+
+<h2 id="label-Sometimes+you+want+a+non-trivial+default+-28not+just+0-2C+-27-27-2C+etc-29-2C+however.">Sometimes you want a non-trivial default (not just 0, &#39;&#39;, etc), however.</h2>
+
+<p>## EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer ## =&gt; 0
+EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset: 250 ## =&gt;
+250</p>
+
+<h2 id="label-Note+that+-22if_unset-22+values+are+used+as-is-2C+with+no+type+conversion.">Note that “if_unset” values are used as-is, with no type conversion.</h2>
+
+<p>## EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset:
+&#39;oof!&#39; ## =&gt; &#39;oof!&#39; “`</p>
 <hr>
 
 <p>The named <code>:as</code> value is required. Allowed values are:</p>
@@ -131,8 +146,7 @@ the repo docs</a> for the full EnvParser documentation.</p>
 
 <h2 id="label-Feature+Roadmap+-2F+Future+Development">Feature Roadmap / Future Development</h2>
 
-<p>Additional features/options coming in the future: - An
-<code>:if_unset</code> option to more easily set default values. - A
+<p>Additional features/options coming in the future: - A
 <code>:from_set</code> option to restrict acceptable values to those on a
 given list. - An <code>EnvParser.load</code> method that will not only
 parse the given value, but will set a constant, easily converting
@@ -172,7 +186,7 @@ href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Wed Nov 29 06:44:05 2017 by
+  Generated on Wed Nov 29 17:00:45 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -100,7 +100,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Nov 29 17:00:46 2017 by
+  Generated on Wed Nov 29 18:34:06 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -100,7 +100,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Nov 29 06:44:05 2017 by
+  Generated on Wed Nov 29 17:00:46 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/lib/env_parser/version.rb
+++ b/lib/env_parser/version.rb
@@ -1,3 +1,3 @@
 class EnvParser
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.3.0'.freeze
 end

--- a/spec/env_parser_spec.rb
+++ b/spec/env_parser_spec.rb
@@ -113,5 +113,12 @@ RSpec.describe EnvParser do
 
       expect(EnvParser.parse('99', as: :float, if_unset: 25.0)).to eq(99.0)
     end
+
+    it 'only allows values from a limited set' do
+      expect(EnvParser.parse('25', as: :integer, from_set: [20, 25, 30])).to eq(25)
+      expect { EnvParser.parse('25', as: :integer, from_set: [1, 2, 3]) }.to raise_exception(EnvParser::ValueNotAllowed)
+
+      expect(EnvParser.parse(nil, as: :integer, if_unset: 9, from_set: [1, 2, 3])).to eq(9)
+    end
   end
 end


### PR DESCRIPTION
This corrects a documentation omission from the 0.2.0 release, adds a "from_set" option, and bumps the version to 0.3.0.