### PR TITLE
fix: NoMethodError in "parse" if no "as" option is given

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    env_parser (0.4.0)
+    env_parser (0.4.1)
       activesupport (>= 5.0.0)
 
 GEM

--- a/lib/env_parser.rb
+++ b/lib/env_parser.rb
@@ -58,7 +58,7 @@ class EnvParser
 
       return options[:if_unset] if value.blank? && options.key?(:if_unset)
 
-      value = case options[:as].to_sym
+      value = case options[:as]
               when :string then parse_string(value)
               when :symbol then parse_symbol(value)
               when :boolean then parse_boolean(value)

--- a/lib/env_parser/version.rb
+++ b/lib/env_parser/version.rb
@@ -1,3 +1,3 @@
 class EnvParser
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end


### PR DESCRIPTION
This fixes a NoMethodError issue and bumps the version to 0.4.1.