### PR TITLE
add: "register" usage with variable *list*

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    env_parser (0.4.1)
+    env_parser (0.5.0)
       activesupport (>= 5.0.0)
 
 GEM

--- a/docs/EnvParser.html
+++ b/docs/EnvParser.html
@@ -130,7 +130,7 @@ different data types.</p>
       <dt id="VERSION-constant" class="">VERSION =
         
       </dt>
-      <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>0.4.0</span><span class='tstring_end'>&#39;</span></span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
+      <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>0.5.0</span><span class='tstring_end'>&#39;</span></span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
     
   </dl>
 
@@ -403,7 +403,7 @@ value will raise an ArgumentError exception.</p>
 
   <span class='kw'>return</span> <span class='id identifier rubyid_options'>options</span><span class='lbracket'>[</span><span class='symbol'>:if_unset</span><span class='rbracket'>]</span> <span class='kw'>if</span> <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_blank?'>blank?</span> <span class='op'>&amp;&amp;</span> <span class='id identifier rubyid_options'>options</span><span class='period'>.</span><span class='id identifier rubyid_key?'>key?</span><span class='lparen'>(</span><span class='symbol'>:if_unset</span><span class='rparen'>)</span>
 
-  <span class='id identifier rubyid_value'>value</span> <span class='op'>=</span> <span class='kw'>case</span> <span class='id identifier rubyid_options'>options</span><span class='lbracket'>[</span><span class='symbol'>:as</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_to_sym'>to_sym</span>
+  <span class='id identifier rubyid_value'>value</span> <span class='op'>=</span> <span class='kw'>case</span> <span class='id identifier rubyid_options'>options</span><span class='lbracket'>[</span><span class='symbol'>:as</span><span class='rbracket'>]</span>
           <span class='kw'>when</span> <span class='symbol'>:string</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_string'>parse_string</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
           <span class='kw'>when</span> <span class='symbol'>:symbol</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_symbol'>parse_symbol</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
           <span class='kw'>when</span> <span class='symbol'>:boolean</span> <span class='kw'>then</span> <span class='id identifier rubyid_parse_boolean'>parse_boolean</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span>
@@ -438,6 +438,22 @@ value will raise an ArgumentError exception.</p>
 <p>Parses the referenced value and creates a matching constant in the
 requested context.</p>
 
+<p>Multiple calls to “register” may be shortcutted by passing in a Hash with
+the same keys as those in the “from” Hash and each value being the
+“register” options set for each variable&#39;s “register” call.</p>
+<pre class="code ruby"><code class="ruby">
+  ## Example shortcut usage:
+
+  EnvParser.register :A, from: one_hash, as: :integer
+  EnvParser.register :B, from: another_hash, as: :string, if_unset: &#39;none&#39;
+
+  ## ... is equivalent to ...
+
+  EnvParser.register(
+    A: { from: ENV, as: :integer }
+    B: { from: other_hash, as: :string, if_unset: &#39;none&#39; }
+  )
+</code></pre>
 
   </div>
 </div>
@@ -578,24 +594,6 @@ Kernel (making it a global constant).</p>
       <pre class="lines">
 
 
-101
-102
-103
-104
-105
-106
-107
-108
-109
-110
-111
-112
-113
-114
-115
-116
-117
-118
 119
 120
 121
@@ -604,12 +602,38 @@ Kernel (making it a global constant).</p>
 124
 125
 126
-127</pre>
+127
+128
+129
+130
+131
+132
+133
+134
+135
+136
+137
+138
+139
+140
+141
+142
+143
+144
+145
+146
+147
+148
+149</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/env_parser.rb', line 101</span>
+      <pre class="code"><span class="info file"># File 'lib/env_parser.rb', line 119</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_register'>register</span><span class='lparen'>(</span><span class='id identifier rubyid_name'>name</span><span class='comma'>,</span> <span class='id identifier rubyid_options'>options</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='comment'>## We want to allow for registering multiple variables simultaneously via a single `.register`
+</span>  <span class='comment'>## method call.
+</span>  <span class='kw'>return</span> <span class='id identifier rubyid_register_all'>register_all</span><span class='lparen'>(</span><span class='id identifier rubyid_name'>name</span><span class='rparen'>)</span> <span class='kw'>if</span> <span class='id identifier rubyid_name'>name</span><span class='period'>.</span><span class='id identifier rubyid_is_a?'>is_a?</span> <span class='const'>Hash</span>
+
   <span class='id identifier rubyid_from'>from</span> <span class='op'>=</span> <span class='id identifier rubyid_options'>options</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:from</span><span class='comma'>,</span> <span class='const'>ENV</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_within'>within</span> <span class='op'>=</span> <span class='id identifier rubyid_options'>options</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:within</span><span class='comma'>,</span> <span class='const'>Kernel</span><span class='rparen'>)</span>
 
@@ -646,7 +670,7 @@ Kernel (making it a global constant).</p>
 </div>
 
       <div id="footer">
-  Generated on Thu Nov 30 22:44:16 2017 by
+  Generated on Sun Dec  3 14:43:03 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/EnvParser/ValueNotAllowed.html
+++ b/docs/EnvParser/ValueNotAllowed.html
@@ -126,7 +126,7 @@ option.</p>
 </div>
 
       <div id="footer">
-  Generated on Thu Nov 30 22:44:16 2017 by
+  Generated on Sun Dec  3 14:43:03 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -112,7 +112,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Nov 30 22:44:16 2017 by
+  Generated on Sun Dec  3 14:43:03 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -93,100 +93,144 @@ simple.</p>
 
 <h2 id="label-Usage">Usage</h2>
 
-<p>Basic EnvParser usage: “`ruby</p>
+<h4 id="label-Basic+EnvParser+usage-3A">Basic EnvParser usage:</h4>
 
-<h2 id="label-Returns+ENV+as+an+Integer.">Returns <a href="'TIMEOUT_MS'">ENV</a> as an Integer.</h2>
+<pre class="code ruby"><code class="ruby"><span class='comment'>## Returns ENV[&#39;TIMEOUT_MS&#39;] as an Integer.
+</span><span class='comment'>## Yields 0 if ENV[&#39;TIMEOUT_MS&#39;] is unset or nil.
+</span><span class='comment'>##
+</span><span class='id identifier rubyid_timeout_ms'>timeout_ms</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>TIMEOUT_MS</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span>
 
-<h2 id="label-Yields+0+if+ENV+is+unset+or+nil.">Yields 0 if <a href="'TIMEOUT_MS'">ENV</a> is unset or nil.</h2>
-
-<p>## timeout_ms = EnvParser.parse <a href="'TIMEOUT_MS'">ENV</a>, as:
-:integer</p>
-
-<h2 id="label-LESS+TYPING-2C+PLZ-21+-3A-28">LESS TYPING, PLZ! :(</h2>
-
-<h2 id="label-If+you+pass+in+a+Symbol+instead+of+a+String-2C+EnvParser">If you pass in a Symbol instead of a String, EnvParser</h2>
-
-<h2 id="label-will+use+the+value+behind+the+matching+String+key+in+ENV.">will use the value behind the matching String key in ENV.</h2>
-
-<h2 id="label-28i.e.+passing+in+ENV-5B-27X-27-5D+is+equivalent+to+passing+in+-3AX-29">(i.e. passing in <code>ENV['X']</code> is equivalent to passing in <code>:X</code>)</h2>
-
-<p>## timeout_ms = EnvParser.parse :TIMEOUT_MS, as: :integer</p>
-
-<h2 id="label-If+the+ENV+variable+you+want+is+unset+-28nil-29+or+blank+-28-27-27-29-2C">If the ENV variable you want is unset (<code>nil</code>) or blank (<code>&#39;&#39;</code>),</h2>
-
-<h2 id="label-the+return+value+is+a+sensible+default+for+the+given+-22as-22+type.">the return value is a sensible default for the given “as” type.</h2>
-
-<h2 id="label-Sometimes+you+want+a+non-trivial+default+-28not+just+0-2C+-27-27-2C+etc-29-2C+however.">Sometimes you want a non-trivial default (not just 0, &#39;&#39;, etc), however.</h2>
-
-<p>## EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer ## =&gt; 0
-EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset: 250 ## =&gt;
-250</p>
-
-<h2 id="label-Note+that+-22if_unset-22+values+are+used+as-is-2C+with+no+type+conversion.">Note that “if_unset” values are used as-is, with no type conversion.</h2>
-
-<p>## EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset:
-&#39;Whoops!&#39; ## =&gt; &#39;Whoops!&#39;</p>
-
-<h2 id="label-Sometimes+setting+the+type+alone+is+a+bit+too+open-ended.">Sometimes setting the type alone is a bit too open-ended.</h2>
-
-<h2 id="label-The+-22from_set-22+option+lets+you+restrict+the+set+of+allowed+values.">The “from_set” option lets you restrict the set of allowed values.</h2>
-
-<p>## EnvParser.parse :API_TO_USE, as: :symbol, from_set: %i[internal
-external] EnvParser.parse :SOME_CUSTOM_NETWORK_PORT, as: :integer,
-from_set: (1..65535), if_unset: 80</p>
-
-<h2 id="label-And+if+the+value+is+not+allowed...">And if the value is not allowed…</h2>
-
-<p>## EnvParser.parse :NEGATIVE_NUMBER, as: :integer, from_set: (1..5) ##
-=&gt; raises EnvParser::ValueNotAllowed</p>
-
-<h2 id="label-You+can+also+SET+CONSTANTS+DIRECTLY+FROM+YOUR+ENV+VARIABLES.">You can also SET CONSTANTS DIRECTLY FROM YOUR ENV VARIABLES.</h2>
-
-<h2 id="label-Global+constants...">Global constants…</h2>
-
-<p>## <a href="'API_KEY'">ENV</a> = &#39;unbreakable p4$$w0rd&#39;
-EnvParser.register :API_KEY, as: :string API_KEY ## =&gt; &#39;unbreakable
-p4$$w0rd&#39; (registered within the Kernel module, so it&#39;s available
-everywhere)</p>
-
-<h2 id="label-...+and+class-2Fmodule+constants-21">… and class/module constants!</h2>
-
-<p>## <a href="'ULTIMATE_LINK'">ENV</a> = &#39;<a
-href="https://youtu.be/L_jWHffIx5E">youtu.be/L_jWHffIx5E</a>&#39;
-EnvParser.register :ULTIMATE_LINK, as: :string, within: URI
-URI::ULTIMATE_LINK ## =&gt; That sweet, sweet link we just set.
-ULTIMATE_LINK ## =&gt; raises NameError (the un-namespaced constant is only
-in scope within the URI module) “`</p>
+<span class='comment'>## LESS TYPING, PLZ!  :(
+</span><span class='comment'>## If you pass in a Symbol instead of a String, EnvParser
+</span><span class='comment'>## will use the value behind the matching String key in ENV.
+</span><span class='comment'>## (i.e. passing in ENV[&#39;X&#39;] is equivalent to passing in :X)
+</span><span class='comment'>##
+</span><span class='id identifier rubyid_timeout_ms'>timeout_ms</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='symbol'>:TIMEOUT_MS</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span>
+</code></pre>
 <hr>
 
-<p>The named <code>:as</code> value is required. Allowed values are:</p>
-
-<p>| <code>:as</code> value | type returned | |—————————–|———————————| |
-:string | String | | :symbol | Symbol | | :boolean | TrueValue / FalseValue
-| | :int / :integer | Integer | | :float / :decimal / :number | Float | |
-:json | &lt; depends on JSON given &gt; | | :array | Array | | :hash | Hash
-|</p>
-
+<p>The named <code>:as</code> parameter is required. Allowed values are:</p>
+<table>
+  <tbody>
+    <tr>
+      <th><code>:as</code> value</th>
+      <th>type returned</th>
+    </tr>
+  </tbody>
+  <tbody>
+    <tr>
+      <td>:string</td>
+      <td>String</td>
+    </tr>
+    <tr>
+      <td>:symbol</td>
+      <td>Symbol</td>
+    </tr>
+    <tr>
+      <td>:boolean</td>
+      <td>TrueValue / FalseValue</td>
+    </tr>
+    <tr>
+      <td>:int / :integer</td>
+      <td>Integer</td>
+    </tr>
+    <tr>
+      <td>:float / :decimal / :number</td>
+      <td>Float</td>
+    </tr>
+    <tr>
+      <td>:json</td>
+      <td>&lt; depends on JSON given &gt;</td>
+    </tr>
+    <tr>
+      <td>:array</td>
+      <td>Array</td>
+    </tr>
+    <tr>
+      <td>:hash</td>
+      <td>Hash</td>
+    </tr>
+  </tbody>
+</table>
 <p>Note JSON is parsed using <em>quirks-mode</em> (meaning &#39;true&#39;,
 &#39;25&#39;, and &#39;null&#39; are all considered valid, parseable JSON).</p>
+
+<h4 id="label-Setting+non-trivial+defaults-3A">Setting non-trivial defaults:</h4>
+
+<pre class="code ruby"><code class="ruby"><span class='comment'>## If the ENV variable you want is unset (nil) or blank (&#39;&#39;),
+</span><span class='comment'>## the return value is a sensible default for the given &quot;as&quot; type
+</span><span class='comment'>## (0 or 0.0 for numbers, an empty tring, an empty Array or Hash, etc).
+</span><span class='comment'>## Sometimes you want a non-trivial default, however.
+</span><span class='comment'>##
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='symbol'>:MISSING_ENV_VARIABLE</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span> <span class='comment'>## =&gt; 0
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='symbol'>:MISSING_ENV_VARIABLE</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span><span class='comma'>,</span> <span class='label'>if_unset:</span> <span class='int'>250</span> <span class='comment'>## =&gt; 250
+</span>
+<span class='comment'>## Note that &quot;if_unset&quot; values are used as-is, with no type conversion.
+</span><span class='comment'>##
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='symbol'>:MISSING_ENV_VARIABLE</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span><span class='comma'>,</span> <span class='label'>if_unset:</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>Whoops!</span><span class='tstring_end'>&#39;</span></span> <span class='comment'>## =&gt; &#39;Whoops!&#39;
+</span></code></pre>
+
+<h4 id="label-Validation+of+parsed+ENV+values-3A">Validation of parsed ENV values:</h4>
+
+<pre class="code ruby"><code class="ruby"><span class='comment'>## Sometimes setting the type alone is a bit too open-ended.
+</span><span class='comment'>## The &quot;from_set&quot; option lets you restrict the set of allowed values.
+</span><span class='comment'>##
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='symbol'>:API_TO_USE</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:symbol</span><span class='comma'>,</span> <span class='label'>from_set:</span> <span class='qsymbols_beg'>%i[</span><span class='tstring_content'>internal</span><span class='words_sep'> </span><span class='tstring_content'>external</span><span class='words_sep'>]</span>
+<span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='symbol'>:SOME_CUSTOM_NETWORK_PORT</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span><span class='comma'>,</span> <span class='label'>from_set:</span> <span class='lparen'>(</span><span class='int'>1</span><span class='op'>..</span><span class='int'>65535</span><span class='rparen'>)</span><span class='comma'>,</span> <span class='label'>if_unset:</span> <span class='int'>80</span>
+
+<span class='comment'>## And if the value is not allowed...
+</span><span class='comment'>##
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='symbol'>:NEGATIVE_NUMBER</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span><span class='comma'>,</span> <span class='label'>from_set:</span> <span class='lparen'>(</span><span class='int'>1</span><span class='op'>..</span><span class='int'>5</span><span class='rparen'>)</span> <span class='comment'>## =&gt; raises EnvParser::ValueNotAllowed
+</span></code></pre>
+
+<h4 id="label-Turning+ENV+values+into+constants-3A">Turning ENV values into constants:</h4>
+
+<pre class="code ruby"><code class="ruby"><span class='comment'>## Global constants...
+</span><span class='comment'>##
+</span><span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>API_KEY</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='comment'>## =&gt; &#39;unbreakable p4$$w0rd&#39; (Set elsewhere, like a &quot;.env&quot; file.)
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_register'><span class='object_link'><a href="EnvParser.html#register-class_method" title="EnvParser.register (method)">register</a></span></span> <span class='symbol'>:API_KEY</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:string</span>
+<span class='const'>API_KEY</span> <span class='comment'>## =&gt; &#39;unbreakable p4$$w0rd&#39; (registered within the Kernel module, so it&#39;s available everywhere)
+</span>
+<span class='comment'>## ... and class/module constants!
+</span><span class='comment'>##
+</span><span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>ULTIMATE_LINK</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='comment'>## =&gt; &#39;https://youtu.be/L_jWHffIx5E&#39; (Set elsewhere, like a &quot;.env&quot; file.)
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_register'><span class='object_link'><a href="EnvParser.html#register-class_method" title="EnvParser.register (method)">register</a></span></span> <span class='symbol'>:ULTIMATE_LINK</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:string</span><span class='comma'>,</span> <span class='label'>within:</span> <span class='const'>URI</span>
+<span class='const'>URI</span><span class='op'>::</span><span class='const'>ULTIMATE_LINK</span> <span class='comment'>## =&gt; &#39;https://youtu.be/L_jWHffIx5E&#39; (You know you want to check it out!)
+</span><span class='const'>ULTIMATE_LINK</span> <span class='comment'>## =&gt; raises NameError (the un-namespaced constant is only in scope within the URI module)
+</span></code></pre>
+
+<h4 id="label-Quickly+registering+multiple+ENV-derived+constants-3A">Quickly registering multiple ENV-derived constants:</h4>
+
+<pre class="code ruby"><code class="ruby"><span class='comment'>## You can also set multiple constants in one call, which is considerably cleaner to read:
+</span><span class='comment'>##
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_register'><span class='object_link'><a href="EnvParser.html#register-class_method" title="EnvParser.register (method)">register</a></span></span> <span class='symbol'>:A</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:string</span>
+<span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_register'><span class='object_link'><a href="EnvParser.html#register-class_method" title="EnvParser.register (method)">register</a></span></span> <span class='symbol'>:B</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span><span class='comma'>,</span> <span class='label'>if_unset:</span> <span class='int'>25</span>
+<span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_register'><span class='object_link'><a href="EnvParser.html#register-class_method" title="EnvParser.register (method)">register</a></span></span> <span class='symbol'>:C</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:boolean</span><span class='comma'>,</span> <span class='label'>if_unset:</span> <span class='kw'>true</span>
+<span class='comment'>##
+</span><span class='comment'>## ... is equivalent to ...
+</span><span class='comment'>##
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_register'><span class='object_link'><a href="EnvParser.html#register-class_method" title="EnvParser.register (method)">register</a></span></span><span class='lparen'>(</span>
+  <span class='label'>A:</span> <span class='lbrace'>{</span> <span class='label'>as:</span> <span class='symbol'>:string</span> <span class='rbrace'>}</span><span class='comma'>,</span>
+  <span class='label'>B:</span> <span class='lbrace'>{</span> <span class='label'>as:</span> <span class='symbol'>:integer</span><span class='comma'>,</span> <span class='label'>if_unset:</span> <span class='int'>25</span> <span class='rbrace'>}</span><span class='comma'>,</span>
+  <span class='label'>C:</span> <span class='lbrace'>{</span> <span class='label'>as:</span> <span class='symbol'>:boolean</span><span class='comma'>,</span> <span class='label'>if_unset:</span> <span class='kw'>true</span> <span class='rbrace'>}</span>
+<span class='rparen'>)</span>
+</code></pre>
 <hr>
 
-<p><a
-href="https://github.com/nestor-custodio/env_parser/blob/master/docs/index.html">Consult
-the repo docs</a> for the full EnvParser documentation.</p>
+<p><a href="http://nestor-custodio.github.io/env_parser">Consult the repo
+docs</a> for the full EnvParser documentation.</p>
 
 <h2 id="label-Feature+Roadmap+-2F+Future+Development">Feature Roadmap / Future Development</h2>
 
-<p>Additional features/options coming in the future: - An
-<code>EnvParser.register_all</code> method to shortcut multiple
-<code>.register</code> calls. - A means to <strong>optionally</strong> bind
-<code>#parse</code>, <code>#regiter</code>, and <code>#register_all</code>
-methods onto <code>ENV</code>. Because <code>ENV.parse ...</code> reads
-better than <code>EnvParser.parse ...</code>. - A <code>validator</code>
-option that lets you pass in a validator lambda/block for things more
-complex than what a simple <code>from_set</code> can enforce. - A means to
-register validation blocks as new “as” types. This will allow for custom
-“as” types like <code>:url</code>, <code>:email</code>, etc. - … ?</p>
+<p>Additional features/options coming in the future: - A means to
+<strong>optionally</strong> bind <code>#parse</code>,
+<code>#regiter</code>, and <code>#register_all</code> methods onto
+<code>ENV</code>. Because <code>ENV.parse ...</code> reads better than
+<code>EnvParser.parse ...</code>. - A <code>validator</code> option that
+lets you pass in a validator lambda/block for things more complex than what
+a simple <code>from_set</code> can enforce. - A means to register
+validation blocks as new “as” types. This will allow for custom “as” types
+like <code>:url</code>, <code>:email</code>, etc. - … ?</p>
 
 <h2 id="label-Contribution+-2F+Development">Contribution / Development</h2>
 
@@ -217,7 +261,7 @@ href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Thu Nov 30 22:44:16 2017 by
+  Generated on Sun Dec  3 14:43:03 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -93,100 +93,144 @@ simple.</p>
 
 <h2 id="label-Usage">Usage</h2>
 
-<p>Basic EnvParser usage: “`ruby</p>
+<h4 id="label-Basic+EnvParser+usage-3A">Basic EnvParser usage:</h4>
 
-<h2 id="label-Returns+ENV+as+an+Integer.">Returns <a href="'TIMEOUT_MS'">ENV</a> as an Integer.</h2>
+<pre class="code ruby"><code class="ruby"><span class='comment'>## Returns ENV[&#39;TIMEOUT_MS&#39;] as an Integer.
+</span><span class='comment'>## Yields 0 if ENV[&#39;TIMEOUT_MS&#39;] is unset or nil.
+</span><span class='comment'>##
+</span><span class='id identifier rubyid_timeout_ms'>timeout_ms</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>TIMEOUT_MS</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span>
 
-<h2 id="label-Yields+0+if+ENV+is+unset+or+nil.">Yields 0 if <a href="'TIMEOUT_MS'">ENV</a> is unset or nil.</h2>
-
-<p>## timeout_ms = EnvParser.parse <a href="'TIMEOUT_MS'">ENV</a>, as:
-:integer</p>
-
-<h2 id="label-LESS+TYPING-2C+PLZ-21+-3A-28">LESS TYPING, PLZ! :(</h2>
-
-<h2 id="label-If+you+pass+in+a+Symbol+instead+of+a+String-2C+EnvParser">If you pass in a Symbol instead of a String, EnvParser</h2>
-
-<h2 id="label-will+use+the+value+behind+the+matching+String+key+in+ENV.">will use the value behind the matching String key in ENV.</h2>
-
-<h2 id="label-28i.e.+passing+in+ENV-5B-27X-27-5D+is+equivalent+to+passing+in+-3AX-29">(i.e. passing in <code>ENV['X']</code> is equivalent to passing in <code>:X</code>)</h2>
-
-<p>## timeout_ms = EnvParser.parse :TIMEOUT_MS, as: :integer</p>
-
-<h2 id="label-If+the+ENV+variable+you+want+is+unset+-28nil-29+or+blank+-28-27-27-29-2C">If the ENV variable you want is unset (<code>nil</code>) or blank (<code>&#39;&#39;</code>),</h2>
-
-<h2 id="label-the+return+value+is+a+sensible+default+for+the+given+-22as-22+type.">the return value is a sensible default for the given “as” type.</h2>
-
-<h2 id="label-Sometimes+you+want+a+non-trivial+default+-28not+just+0-2C+-27-27-2C+etc-29-2C+however.">Sometimes you want a non-trivial default (not just 0, &#39;&#39;, etc), however.</h2>
-
-<p>## EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer ## =&gt; 0
-EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset: 250 ## =&gt;
-250</p>
-
-<h2 id="label-Note+that+-22if_unset-22+values+are+used+as-is-2C+with+no+type+conversion.">Note that “if_unset” values are used as-is, with no type conversion.</h2>
-
-<p>## EnvParser.parse :MISSING_ENV_VARIABLE, as: :integer, if_unset:
-&#39;Whoops!&#39; ## =&gt; &#39;Whoops!&#39;</p>
-
-<h2 id="label-Sometimes+setting+the+type+alone+is+a+bit+too+open-ended.">Sometimes setting the type alone is a bit too open-ended.</h2>
-
-<h2 id="label-The+-22from_set-22+option+lets+you+restrict+the+set+of+allowed+values.">The “from_set” option lets you restrict the set of allowed values.</h2>
-
-<p>## EnvParser.parse :API_TO_USE, as: :symbol, from_set: %i[internal
-external] EnvParser.parse :SOME_CUSTOM_NETWORK_PORT, as: :integer,
-from_set: (1..65535), if_unset: 80</p>
-
-<h2 id="label-And+if+the+value+is+not+allowed...">And if the value is not allowed…</h2>
-
-<p>## EnvParser.parse :NEGATIVE_NUMBER, as: :integer, from_set: (1..5) ##
-=&gt; raises EnvParser::ValueNotAllowed</p>
-
-<h2 id="label-You+can+also+SET+CONSTANTS+DIRECTLY+FROM+YOUR+ENV+VARIABLES.">You can also SET CONSTANTS DIRECTLY FROM YOUR ENV VARIABLES.</h2>
-
-<h2 id="label-Global+constants...">Global constants…</h2>
-
-<p>## <a href="'API_KEY'">ENV</a> = &#39;unbreakable p4$$w0rd&#39;
-EnvParser.register :API_KEY, as: :string API_KEY ## =&gt; &#39;unbreakable
-p4$$w0rd&#39; (registered within the Kernel module, so it&#39;s available
-everywhere)</p>
-
-<h2 id="label-...+and+class-2Fmodule+constants-21">… and class/module constants!</h2>
-
-<p>## <a href="'ULTIMATE_LINK'">ENV</a> = &#39;<a
-href="https://youtu.be/L_jWHffIx5E">youtu.be/L_jWHffIx5E</a>&#39;
-EnvParser.register :ULTIMATE_LINK, as: :string, within: URI
-URI::ULTIMATE_LINK ## =&gt; That sweet, sweet link we just set.
-ULTIMATE_LINK ## =&gt; raises NameError (the un-namespaced constant is only
-in scope within the URI module) “`</p>
+<span class='comment'>## LESS TYPING, PLZ!  :(
+</span><span class='comment'>## If you pass in a Symbol instead of a String, EnvParser
+</span><span class='comment'>## will use the value behind the matching String key in ENV.
+</span><span class='comment'>## (i.e. passing in ENV[&#39;X&#39;] is equivalent to passing in :X)
+</span><span class='comment'>##
+</span><span class='id identifier rubyid_timeout_ms'>timeout_ms</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='symbol'>:TIMEOUT_MS</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span>
+</code></pre>
 <hr>
 
-<p>The named <code>:as</code> value is required. Allowed values are:</p>
-
-<p>| <code>:as</code> value | type returned | |—————————–|———————————| |
-:string | String | | :symbol | Symbol | | :boolean | TrueValue / FalseValue
-| | :int / :integer | Integer | | :float / :decimal / :number | Float | |
-:json | &lt; depends on JSON given &gt; | | :array | Array | | :hash | Hash
-|</p>
-
+<p>The named <code>:as</code> parameter is required. Allowed values are:</p>
+<table>
+  <tbody>
+    <tr>
+      <th><code>:as</code> value</th>
+      <th>type returned</th>
+    </tr>
+  </tbody>
+  <tbody>
+    <tr>
+      <td>:string</td>
+      <td>String</td>
+    </tr>
+    <tr>
+      <td>:symbol</td>
+      <td>Symbol</td>
+    </tr>
+    <tr>
+      <td>:boolean</td>
+      <td>TrueValue / FalseValue</td>
+    </tr>
+    <tr>
+      <td>:int / :integer</td>
+      <td>Integer</td>
+    </tr>
+    <tr>
+      <td>:float / :decimal / :number</td>
+      <td>Float</td>
+    </tr>
+    <tr>
+      <td>:json</td>
+      <td>&lt; depends on JSON given &gt;</td>
+    </tr>
+    <tr>
+      <td>:array</td>
+      <td>Array</td>
+    </tr>
+    <tr>
+      <td>:hash</td>
+      <td>Hash</td>
+    </tr>
+  </tbody>
+</table>
 <p>Note JSON is parsed using <em>quirks-mode</em> (meaning &#39;true&#39;,
 &#39;25&#39;, and &#39;null&#39; are all considered valid, parseable JSON).</p>
+
+<h4 id="label-Setting+non-trivial+defaults-3A">Setting non-trivial defaults:</h4>
+
+<pre class="code ruby"><code class="ruby"><span class='comment'>## If the ENV variable you want is unset (nil) or blank (&#39;&#39;),
+</span><span class='comment'>## the return value is a sensible default for the given &quot;as&quot; type
+</span><span class='comment'>## (0 or 0.0 for numbers, an empty tring, an empty Array or Hash, etc).
+</span><span class='comment'>## Sometimes you want a non-trivial default, however.
+</span><span class='comment'>##
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='symbol'>:MISSING_ENV_VARIABLE</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span> <span class='comment'>## =&gt; 0
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='symbol'>:MISSING_ENV_VARIABLE</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span><span class='comma'>,</span> <span class='label'>if_unset:</span> <span class='int'>250</span> <span class='comment'>## =&gt; 250
+</span>
+<span class='comment'>## Note that &quot;if_unset&quot; values are used as-is, with no type conversion.
+</span><span class='comment'>##
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='symbol'>:MISSING_ENV_VARIABLE</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span><span class='comma'>,</span> <span class='label'>if_unset:</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>Whoops!</span><span class='tstring_end'>&#39;</span></span> <span class='comment'>## =&gt; &#39;Whoops!&#39;
+</span></code></pre>
+
+<h4 id="label-Validation+of+parsed+ENV+values-3A">Validation of parsed ENV values:</h4>
+
+<pre class="code ruby"><code class="ruby"><span class='comment'>## Sometimes setting the type alone is a bit too open-ended.
+</span><span class='comment'>## The &quot;from_set&quot; option lets you restrict the set of allowed values.
+</span><span class='comment'>##
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='symbol'>:API_TO_USE</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:symbol</span><span class='comma'>,</span> <span class='label'>from_set:</span> <span class='qsymbols_beg'>%i[</span><span class='tstring_content'>internal</span><span class='words_sep'> </span><span class='tstring_content'>external</span><span class='words_sep'>]</span>
+<span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='symbol'>:SOME_CUSTOM_NETWORK_PORT</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span><span class='comma'>,</span> <span class='label'>from_set:</span> <span class='lparen'>(</span><span class='int'>1</span><span class='op'>..</span><span class='int'>65535</span><span class='rparen'>)</span><span class='comma'>,</span> <span class='label'>if_unset:</span> <span class='int'>80</span>
+
+<span class='comment'>## And if the value is not allowed...
+</span><span class='comment'>##
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_parse'><span class='object_link'><a href="EnvParser.html#parse-class_method" title="EnvParser.parse (method)">parse</a></span></span> <span class='symbol'>:NEGATIVE_NUMBER</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span><span class='comma'>,</span> <span class='label'>from_set:</span> <span class='lparen'>(</span><span class='int'>1</span><span class='op'>..</span><span class='int'>5</span><span class='rparen'>)</span> <span class='comment'>## =&gt; raises EnvParser::ValueNotAllowed
+</span></code></pre>
+
+<h4 id="label-Turning+ENV+values+into+constants-3A">Turning ENV values into constants:</h4>
+
+<pre class="code ruby"><code class="ruby"><span class='comment'>## Global constants...
+</span><span class='comment'>##
+</span><span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>API_KEY</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='comment'>## =&gt; &#39;unbreakable p4$$w0rd&#39; (Set elsewhere, like a &quot;.env&quot; file.)
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_register'><span class='object_link'><a href="EnvParser.html#register-class_method" title="EnvParser.register (method)">register</a></span></span> <span class='symbol'>:API_KEY</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:string</span>
+<span class='const'>API_KEY</span> <span class='comment'>## =&gt; &#39;unbreakable p4$$w0rd&#39; (registered within the Kernel module, so it&#39;s available everywhere)
+</span>
+<span class='comment'>## ... and class/module constants!
+</span><span class='comment'>##
+</span><span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>ULTIMATE_LINK</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='comment'>## =&gt; &#39;https://youtu.be/L_jWHffIx5E&#39; (Set elsewhere, like a &quot;.env&quot; file.)
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_register'><span class='object_link'><a href="EnvParser.html#register-class_method" title="EnvParser.register (method)">register</a></span></span> <span class='symbol'>:ULTIMATE_LINK</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:string</span><span class='comma'>,</span> <span class='label'>within:</span> <span class='const'>URI</span>
+<span class='const'>URI</span><span class='op'>::</span><span class='const'>ULTIMATE_LINK</span> <span class='comment'>## =&gt; &#39;https://youtu.be/L_jWHffIx5E&#39; (You know you want to check it out!)
+</span><span class='const'>ULTIMATE_LINK</span> <span class='comment'>## =&gt; raises NameError (the un-namespaced constant is only in scope within the URI module)
+</span></code></pre>
+
+<h4 id="label-Quickly+registering+multiple+ENV-derived+constants-3A">Quickly registering multiple ENV-derived constants:</h4>
+
+<pre class="code ruby"><code class="ruby"><span class='comment'>## You can also set multiple constants in one call, which is considerably cleaner to read:
+</span><span class='comment'>##
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_register'><span class='object_link'><a href="EnvParser.html#register-class_method" title="EnvParser.register (method)">register</a></span></span> <span class='symbol'>:A</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:string</span>
+<span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_register'><span class='object_link'><a href="EnvParser.html#register-class_method" title="EnvParser.register (method)">register</a></span></span> <span class='symbol'>:B</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:integer</span><span class='comma'>,</span> <span class='label'>if_unset:</span> <span class='int'>25</span>
+<span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_register'><span class='object_link'><a href="EnvParser.html#register-class_method" title="EnvParser.register (method)">register</a></span></span> <span class='symbol'>:C</span><span class='comma'>,</span> <span class='label'>as:</span> <span class='symbol'>:boolean</span><span class='comma'>,</span> <span class='label'>if_unset:</span> <span class='kw'>true</span>
+<span class='comment'>##
+</span><span class='comment'>## ... is equivalent to ...
+</span><span class='comment'>##
+</span><span class='const'><span class='object_link'><a href="EnvParser.html" title="EnvParser (class)">EnvParser</a></span></span><span class='period'>.</span><span class='id identifier rubyid_register'><span class='object_link'><a href="EnvParser.html#register-class_method" title="EnvParser.register (method)">register</a></span></span><span class='lparen'>(</span>
+  <span class='label'>A:</span> <span class='lbrace'>{</span> <span class='label'>as:</span> <span class='symbol'>:string</span> <span class='rbrace'>}</span><span class='comma'>,</span>
+  <span class='label'>B:</span> <span class='lbrace'>{</span> <span class='label'>as:</span> <span class='symbol'>:integer</span><span class='comma'>,</span> <span class='label'>if_unset:</span> <span class='int'>25</span> <span class='rbrace'>}</span><span class='comma'>,</span>
+  <span class='label'>C:</span> <span class='lbrace'>{</span> <span class='label'>as:</span> <span class='symbol'>:boolean</span><span class='comma'>,</span> <span class='label'>if_unset:</span> <span class='kw'>true</span> <span class='rbrace'>}</span>
+<span class='rparen'>)</span>
+</code></pre>
 <hr>
 
-<p><a
-href="https://github.com/nestor-custodio/env_parser/blob/master/docs/index.html">Consult
-the repo docs</a> for the full EnvParser documentation.</p>
+<p><a href="http://nestor-custodio.github.io/env_parser">Consult the repo
+docs</a> for the full EnvParser documentation.</p>
 
 <h2 id="label-Feature+Roadmap+-2F+Future+Development">Feature Roadmap / Future Development</h2>
 
-<p>Additional features/options coming in the future: - An
-<code>EnvParser.register_all</code> method to shortcut multiple
-<code>.register</code> calls. - A means to <strong>optionally</strong> bind
-<code>#parse</code>, <code>#regiter</code>, and <code>#register_all</code>
-methods onto <code>ENV</code>. Because <code>ENV.parse ...</code> reads
-better than <code>EnvParser.parse ...</code>. - A <code>validator</code>
-option that lets you pass in a validator lambda/block for things more
-complex than what a simple <code>from_set</code> can enforce. - A means to
-register validation blocks as new “as” types. This will allow for custom
-“as” types like <code>:url</code>, <code>:email</code>, etc. - … ?</p>
+<p>Additional features/options coming in the future: - A means to
+<strong>optionally</strong> bind <code>#parse</code>,
+<code>#regiter</code>, and <code>#register_all</code> methods onto
+<code>ENV</code>. Because <code>ENV.parse ...</code> reads better than
+<code>EnvParser.parse ...</code>. - A <code>validator</code> option that
+lets you pass in a validator lambda/block for things more complex than what
+a simple <code>from_set</code> can enforce. - A means to register
+validation blocks as new “as” types. This will allow for custom “as” types
+like <code>:url</code>, <code>:email</code>, etc. - … ?</p>
 
 <h2 id="label-Contribution+-2F+Development">Contribution / Development</h2>
 
@@ -217,7 +261,7 @@ href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Thu Nov 30 22:44:16 2017 by
+  Generated on Sun Dec  3 14:43:03 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -100,7 +100,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Nov 30 22:44:16 2017 by
+  Generated on Sun Dec  3 14:43:03 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/lib/env_parser.rb
+++ b/lib/env_parser.rb
@@ -225,7 +225,7 @@ class EnvParser
     ##
     ## @param list [Hash]
     ##
-    ## @regurn [Hash]
+    ## @return [Hash]
     ##
     ## @raise [ArgumentError]
     ##

--- a/lib/env_parser/version.rb
+++ b/lib/env_parser/version.rb
@@ -1,3 +1,3 @@
 class EnvParser
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/spec/env_parser_spec.rb
+++ b/spec/env_parser_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe EnvParser do
 
   describe 'EnvParse.register' do
     it 'ceates global constants' do
-      source_hash = { ABC: 123 }
+      source_hash = { ABC: '123' }
       EnvParser.register(:ABC, from: source_hash, as: :integer)
       expect(ABC).to eq(123)
     end
@@ -137,9 +137,24 @@ RSpec.describe EnvParser do
       module Sample
       end
 
-      source_hash = { XYZ: 456 }
+      source_hash = { XYZ: '456' }
       EnvParser.register(:XYZ, from: source_hash, as: :integer, within: Sample)
       expect(Sample::XYZ).to eq(456)
+    end
+
+    it 'will accept a hash keyed by variable names' do
+      source_hash = { FIRST: 'first', SECOND: '99', THIRD: 'third' }
+      EnvParser.register(
+        FIRST: { from: source_hash, as: :string, if_unset: 'no first' },
+        SECOND: { from: source_hash, as: :integer, if_unste: 'no second' },
+        THIRD: { from: source_hash, as: :string, if_unset: 'no third' },
+        FOURTH: { from: source_hash, as: :boolean, if_unset: 'no fourth' }
+      )
+
+      expect(FIRST).to eq('first')
+      expect(SECOND).to eq(99)
+      expect(THIRD).to eq('third')
+      expect(FOURTH).to eq('no fourth')
     end
   end
 end


### PR DESCRIPTION
This allows for a single "register" call to create multiple variables (by passing in a Hash instead of a single variable name) and bumps the version to 0.5.0.