### PR TITLE
version: declare stable API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    env_parser (0.8.0)
+    env_parser (1.0.0)
       activesupport (>= 5.0.0)
 
 GEM

--- a/docs/EnvParser.html
+++ b/docs/EnvParser.html
@@ -130,7 +130,7 @@ different data types.</p>
       <dt id="VERSION-constant" class="">VERSION =
         
       </dt>
-      <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>0.8.0</span><span class='tstring_end'>&#39;</span></span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
+      <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>1.0.0</span><span class='tstring_end'>&#39;</span></span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
     
   </dl>
 
@@ -1075,7 +1075,7 @@ each value needing validation must give its own “validated_by” Proc.</p>
 </div>
 
       <div id="footer">
-  Generated on Mon Dec 25 00:29:06 2017 by
+  Generated on Mon Dec 25 19:13:02 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/EnvParser/Error.html
+++ b/docs/EnvParser/Error.html
@@ -129,7 +129,7 @@
 </div>
 
       <div id="footer">
-  Generated on Mon Dec 25 00:29:06 2017 by
+  Generated on Mon Dec 25 19:13:03 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/EnvParser/TypeAlreadyDefinedError.html
+++ b/docs/EnvParser/TypeAlreadyDefinedError.html
@@ -133,7 +133,7 @@
 </div>
 
       <div id="footer">
-  Generated on Mon Dec 25 00:29:07 2017 by
+  Generated on Mon Dec 25 19:13:03 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/EnvParser/UnknownTypeError.html
+++ b/docs/EnvParser/UnknownTypeError.html
@@ -133,7 +133,7 @@
 </div>
 
       <div id="footer">
-  Generated on Mon Dec 25 00:29:07 2017 by
+  Generated on Mon Dec 25 19:13:03 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/EnvParser/ValueNotAllowedError.html
+++ b/docs/EnvParser/ValueNotAllowedError.html
@@ -135,7 +135,7 @@ by failing the “validated_by” Proc or yield-block check.</p>
 </div>
 
       <div id="footer">
-  Generated on Mon Dec 25 00:29:07 2017 by
+  Generated on Mon Dec 25 19:13:03 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/EnvParser/ValueNotConvertibleError.html
+++ b/docs/EnvParser/ValueNotConvertibleError.html
@@ -134,7 +134,7 @@ requested type.</p>
 </div>
 
       <div id="footer">
-  Generated on Mon Dec 25 00:29:07 2017 by
+  Generated on Mon Dec 25 19:13:03 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/EnvParserTypes.html
+++ b/docs/EnvParserTypes.html
@@ -117,7 +117,7 @@ for documentation&#39;s sake.</p>
 </div>
 
       <div id="footer">
-  Generated on Mon Dec 25 00:29:06 2017 by
+  Generated on Mon Dec 25 19:13:02 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/EnvParserTypes/BaseTypes.html
+++ b/docs/EnvParserTypes/BaseTypes.html
@@ -150,7 +150,7 @@
 </div>
 
       <div id="footer">
-  Generated on Mon Dec 25 00:29:06 2017 by
+  Generated on Mon Dec 25 19:13:02 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -178,7 +178,7 @@
 </div>
 
       <div id="footer">
-  Generated on Mon Dec 25 00:29:05 2017 by
+  Generated on Mon Dec 25 19:13:01 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -298,7 +298,7 @@ href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Mon Dec 25 00:29:06 2017 by
+  Generated on Mon Dec 25 19:13:02 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -298,7 +298,7 @@ href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
 </div></div>
 
       <div id="footer">
-  Generated on Mon Dec 25 00:29:06 2017 by
+  Generated on Mon Dec 25 19:13:02 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -180,7 +180,7 @@
 </div>
 
       <div id="footer">
-  Generated on Mon Dec 25 00:29:06 2017 by
+  Generated on Mon Dec 25 19:13:02 2017 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.11 (ruby-2.4.2).
 </div>

--- a/lib/env_parser/version.rb
+++ b/lib/env_parser/version.rb
@@ -1,3 +1,3 @@
 class EnvParser
-  VERSION = '0.8.0'.freeze
+  VERSION = '1.0.0'.freeze
 end


### PR DESCRIPTION
The feature set is now at parity with the originally-intended public release. This bumps the gem version to 1.0.0 and declares the existing API stable.