### PR TITLE
fix: circle-ci rspec exec script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,12 @@ jobs:
             mkdir /tmp/test-results
             TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
 
-            bundle exec rspec --format progress \
-                            --format RspecJunitFormatter \
-                            --out /tmp/test-results/rspec.xml \
-                            --format progress \
-                            "${TEST_FILES}"
+            bundle exec rspec --format progress                 \
+                              --format RspecJunitFormatter      \
+                              --out /tmp/test-results/rspec.xml \
+                              --format progress                 \
+                              --                                \
+                              $TEST_FILES
 
       # collect reports
       - store_test_results:


### PR DESCRIPTION
Changes in the CircleCI back-end have necessitated a change to the `bundle exec rspec` command that runs the tets.