### PR TITLE
add: the ability to "autoregister" constants per a config file

### DIFF
--- a/lib/env_parser.rb
+++ b/lib/env_parser.rb
@@ -232,16 +232,22 @@ class EnvParser
 
     ## Reads an "autoregister" file and registers the ENV constants defined therein.
     ##
-    ## The "autoregister" file (see {EnvParser::AUTOREGISTER_FILE}) is read, parsed as YAML,
-    ## sanitized for use as a parameter to {.register_all}, and then passed along for processing.
+    ## The "autoregister" file is read, parsed as YAML, sanitized for use as a parameter to
+    ## {.register_all}, and then passed along for processing. The return value from that
+    ## {.register_all} call is passed through.
+    ##
+    ## @param filename [String]
+    ##   A path for the autoregister file to parse and process. Defaults to
+    ##   {EnvParser::AUTOREGISTER_FILE} if unset.
     ##
     ## @return [Hash]
-    ##   The return value from the {.register_all} call that handles the registration.
+    ##   The return value from the {.register_all} call that handles the actual registration.
     ##
     ## #raise [EnvParser::AutoregisterFileNotFound, EnvParser::UnparseableAutoregisterSpec]
     ##
-    def autoregister
-      autoregister_spec = Psych.load_file(AUTOREGISTER_FILE)
+    def autoregister(filename = nil)
+      filename ||= AUTOREGISTER_FILE
+      autoregister_spec = Psych.load_file(filename)
 
       autoregister_spec.deep_symbolize_keys!
       autoregister_spec.transform_values! do |spec|
@@ -253,7 +259,7 @@ class EnvParser
     ## Psych raises an Errno::ENOENT on file-not-found.
     ##
     rescue Errno::ENOENT
-      raise EnvParser::AutoregisterFileNotFound, %(file not found: "#{AUTOREGISTER_FILE}")
+      raise EnvParser::AutoregisterFileNotFound, %(file not found: "#{filename}")
 
     ## Psych raises a Psych::SyntaxError on unparseable YAML.
     ##

--- a/lib/env_parser.rb
+++ b/lib/env_parser.rb
@@ -226,6 +226,16 @@ class EnvParser
       ENV
     end
 
+    ## Reads an "autoregister" file and registers the ENV constants defined therein.
+    ##
+    ## The "autoregister" file (see {EnvParser::AUTOREGISTER_FILE}) is read, parsed as YAML,
+    ## sanitized for use as a parameter to {.register_all}, and then passed along for processing.
+    ##
+    ## @return [Hash]
+    ##   The return value from the {.register_all} call that handles the registration.
+    ##
+    ## #raise [EnvParser::AutoregisterFileNotFound, EnvParser::UnparseableAutoregisterSpec]
+    ##
     def autoregister
       EnvParser::AUTOREGISTER_FILE = '.env_parser.yml'.freeze
 

--- a/lib/env_parser.rb
+++ b/lib/env_parser.rb
@@ -6,6 +6,10 @@ require 'psych'
 ## The EnvParser class simplifies parsing of environment variables as different data types.
 ##
 class EnvParser
+  ## The default filename to use for {.autoregister} requests.
+  ##
+  AUTOREGISTER_FILE = '.env_parser.yml'.freeze
+
   class << self
     ## Defines a new type for use as the "as" option on a subsequent {.parse} or {.register} call.
     ##
@@ -237,9 +241,7 @@ class EnvParser
     ## #raise [EnvParser::AutoregisterFileNotFound, EnvParser::UnparseableAutoregisterSpec]
     ##
     def autoregister
-      EnvParser::AUTOREGISTER_FILE = '.env_parser.yml'.freeze
-
-      autoregister_spec = Psych.load_file(EnvParser::AUTOREGISTER_FILE)
+      autoregister_spec = Psych.load_file(AUTOREGISTER_FILE)
 
       autoregister_spec.deep_symbolize_keys!
       autoregister_spec.transform_values! do |spec|
@@ -251,7 +253,7 @@ class EnvParser
     ## Psych raises an Errno::ENOENT on file-not-found.
     ##
     rescue Errno::ENOENT
-      raise EnvParser::AutoregisterFileNotFound, %(file not found: "#{EnvParser::AUTOREGISTER_FILE}")
+      raise EnvParser::AutoregisterFileNotFound, %(file not found: "#{AUTOREGISTER_FILE}")
 
     ## Psych raises a Psych::SyntaxError on unparseable YAML.
     ##

--- a/lib/env_parser/autoregister.rb
+++ b/lib/env_parser/autoregister.rb
@@ -4,14 +4,14 @@ require 'psych'
 EnvParser::AUTOREGISTER_FILE = '.env_parser.yml'.freeze
 
 begin
-  auto_register_spec = Psych.load_file(EnvParser::AUTOREGISTER_FILE)
+  autoregister_spec = Psych.load_file(EnvParser::AUTOREGISTER_FILE)
 
-  auto_register_spec.deep_symbolize_keys!
-  auto_register_spec.transform_values! do |spec|
+  autoregister_spec.deep_symbolize_keys!
+  autoregister_spec.transform_values! do |spec|
     spec.slice(:as, :if_unset, :from_set).merge as: spec[:as]&.to_sym
   end
 
-  EnvParser.register auto_register_spec
+  EnvParser.register autoregister_spec
 
 ## Psych raises an Errno::ENOENT on file-not-found.
 ##

--- a/lib/env_parser/autoregister.rb
+++ b/lib/env_parser/autoregister.rb
@@ -1,25 +1,3 @@
 require 'env_parser'
-require 'psych'
 
-EnvParser::AUTOREGISTER_FILE = '.env_parser.yml'.freeze
-
-begin
-  autoregister_spec = Psych.load_file(EnvParser::AUTOREGISTER_FILE)
-
-  autoregister_spec.deep_symbolize_keys!
-  autoregister_spec.transform_values! do |spec|
-    spec.slice(:as, :if_unset, :from_set).merge as: spec[:as]&.to_sym
-  end
-
-  EnvParser.register autoregister_spec
-
-## Psych raises an Errno::ENOENT on file-not-found.
-##
-rescue Errno::ENOENT
-  raise EnvParser::AutoRegisterFileNotFound, %(file not found: "#{EnvParser::AUTOREGISTER_FILE}")
-
-## Psych raises a Psych::SyntaxError on unparseable YAML.
-##
-rescue Psych::SyntaxError => e
-  raise EnvParser::UnparseableAutoRegisterSpec, "malformed YAML in spec file: #{e.message}"
-end
+EnvParser.autoregister

--- a/lib/env_parser/autoregister.rb
+++ b/lib/env_parser/autoregister.rb
@@ -1,9 +1,10 @@
 require 'env_parser'
 require 'psych'
 
+EnvParser::AUTOREGISTER_FILE = '.env_parser.yml'.freeze
+
 begin
-  auto_register_file = '.env_parser.yml'
-  auto_register_spec = Psych.load_file(auto_register_file)
+  auto_register_spec = Psych.load_file(EnvParser::AUTOREGISTER_FILE)
 
   auto_register_spec.deep_symbolize_keys!
   auto_register_spec.transform_values! do |spec|
@@ -15,7 +16,7 @@ begin
 ## Psych raises an Errno::ENOENT on file-not-found.
 ##
 rescue Errno::ENOENT
-  raise EnvParser::AutoRegisterFileNotFound, %(file not found: "#{auto_register_file}")
+  raise EnvParser::AutoRegisterFileNotFound, %(file not found: "#{EnvParser::AUTOREGISTER_FILE}")
 
 ## Psych raises a Psych::SyntaxError on unparseable YAML.
 ##

--- a/lib/env_parser/autoregister.rb
+++ b/lib/env_parser/autoregister.rb
@@ -6,7 +6,10 @@ begin
   auto_register_spec = Psych.load_file(auto_register_file)
 
   auto_register_spec.deep_symbolize_keys!
-  auto_register_spec.transform_values! { |spec| spec.merge as: spec[:as]&.to_sym }
+  auto_register_spec.transform_values! do |spec|
+    spec.slice(:as, :if_unset, :from_set).merge as: spec[:as]&.to_sym
+  end
+
   EnvParser.register auto_register_spec
 
 ## Psych raises an Errno::ENOENT on file-not-found.

--- a/lib/env_parser/autoregister.rb
+++ b/lib/env_parser/autoregister.rb
@@ -1,0 +1,21 @@
+require 'env_parser'
+require 'psych'
+
+begin
+  auto_register_file = '.env_parser.yml'
+  auto_register_spec = Psych.load_file(auto_register_file)
+
+  auto_register_spec.deep_symbolize_keys!
+  auto_register_spec.transform_values! { |spec| spec.merge as: spec[:as]&.to_sym }
+  EnvParser.register auto_register_spec
+
+## Psych raises an Errno::ENOENT on file-not-found.
+##
+rescue Errno::ENOENT
+  raise EnvParser::AutoRegisterFileNotFound, %(file not found: "#{auto_register_file}")
+
+## Psych raises a Psych::SyntaxError on unparseable YAML.
+##
+rescue Psych::SyntaxError => e
+  raise EnvParser::UnparseableAutoRegisterSpec, "malformed YAML in spec file: #{e.message}"
+end

--- a/lib/env_parser/errors.rb
+++ b/lib/env_parser/errors.rb
@@ -26,15 +26,15 @@ class EnvParser
   class ValueNotAllowedError < Error
   end
 
-  ## Error class used to indicate a missing auto-registration spec file (used by the "auto-register"
+  ## Error class used to indicate a missing auto-registration spec file (used by the "autoregister"
   ## feature).
   ##
-  class AutoRegisterFileNotFound < Error
+  class AutoregisterFileNotFound < Error
   end
 
-  ## Error class used to indicate an unparseable auto-registration spec (used by the "auto-register"
+  ## Error class used to indicate an unparseable auto-registration spec (used by the "autoregister"
   ## feature).
   ##
-  class UnparseableAutoRegisterSpec < Error
+  class UnparseableAutoregisterSpec < Error
   end
 end

--- a/lib/env_parser/errors.rb
+++ b/lib/env_parser/errors.rb
@@ -25,4 +25,16 @@ class EnvParser
   ##
   class ValueNotAllowedError < Error
   end
+
+  ## Error class used to indicate a missing auto-registration spec file (used by the "auto-register"
+  ## feature).
+  ##
+  class AutoRegisterFileNotFound < Error
+  end
+
+  ## Error class used to indicate an unparseable auto-registration spec (used by the "auto-register"
+  ## feature).
+  ##
+  class UnparseableAutoRegisterSpec < Error
+  end
 end

--- a/spec/env_parser/types/internet_types_spec.rb
+++ b/spec/env_parser/types/internet_types_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe EnvParser::Types::BaseTypes do
+RSpec.describe EnvParser::Types::InternetTypes do
   it 'can parse ipv4 addresses' do
     expect(EnvParser.parse(nil, as: :ipv4_address)).to eq(nil)
     expect(EnvParser.parse('', as: :ipv4_address)).to eq(nil)

--- a/spec/env_parser_spec.rb
+++ b/spec/env_parser_spec.rb
@@ -5,22 +5,22 @@ RSpec.describe EnvParser do
     expect(EnvParser::VERSION).not_to be nil
   end
 
-  it 'responds to `.define_type`' do
-    expect(EnvParser).to respond_to(:define_type)
-  end
-
   describe 'EnvParser.define_type' do
+    it 'exists' do
+      expect(EnvParser).to respond_to(:define_type)
+    end
+
     it 'can register new types' do
       EnvParser.define_type(:thirty) { |_| 30 }
       expect(EnvParser.parse('dummy value', as: :thirty)).to eq(30)
     end
   end
 
-  it 'responds to `.parse`' do
-    expect(EnvParser).to respond_to(:parse)
-  end
-
   describe 'EnvParser.parse' do
+    it 'exists' do
+      expect(EnvParser).to respond_to(:parse)
+    end
+
     it 'returns the requested default when necessary' do
       expect(EnvParser.parse(nil, as: :integer, if_unset: 25)).to eq(25)
       expect(EnvParser.parse('', as: :integer, if_unset: 25)).to eq(25)
@@ -46,11 +46,11 @@ RSpec.describe EnvParser do
     end
   end
 
-  it 'responds to `.register`' do
-    expect(EnvParser).to respond_to(:register)
-  end
-
   describe 'EnvParse.register' do
+    it 'exists' do
+      expect(EnvParser).to respond_to(:register)
+    end
+
     it 'ceates global constants' do
       source_hash = { ABC: '123' }
       EnvParser.register(:ABC, from: source_hash, as: :integer)
@@ -82,18 +82,18 @@ RSpec.describe EnvParser do
     end
   end
 
-  it 'responds to `.add_env_bindings`' do
-    expect(EnvParser).to respond_to(:add_env_bindings)
-  end
-
   describe 'EnvParser.add_env_bindings' do
     before(:context) { EnvParser.add_env_bindings }
 
-    it 'lets ENV respond to `.parse`' do
-      expect(ENV).to respond_to(:parse)
+    it 'exists' do
+      expect(EnvParser).to respond_to(:add_env_bindings)
     end
 
     describe 'ENV.parse' do
+      it 'now exists' do
+        expect(ENV).to respond_to(:parse)
+      end
+
       it 'interprets input values as ENV keys' do
         ENV['ABC'] = '123'
         expect(ENV.parse('ABC', as: :integer)).to eq(123)
@@ -101,11 +101,11 @@ RSpec.describe EnvParser do
       end
     end
 
-    it 'lets ENV respond to `.register`' do
-      expect(ENV).to respond_to(:register)
-    end
-
     describe 'ENV.register' do
+      it 'now exists' do
+        expect(ENV).to respond_to(:register)
+      end
+
       it 'ceates global constants' do
         ENV['ABCD'] = '1234'
         ENV.register(:ABCD, as: :integer)
@@ -141,11 +141,11 @@ RSpec.describe EnvParser do
     end
   end
 
-  it 'responds to `.autoregister`' do
-    expect(EnvParser).to respond_to(:autoregister)
-  end
-
   describe 'EnvParser.autoregister' do
+    it 'exists' do
+      expect(EnvParser).to respond_to(:autoregister)
+    end
+
     it 'can autoregister constants' do
       filename = Tempfile.open('EnvParser.autoregister.') do |file|
         file.write <<~YAML.chomp
@@ -169,24 +169,22 @@ RSpec.describe EnvParser do
       expect(SOME_STRING).to eq('twelve')
     end
 
-    describe 'error handling' do
-      it 'properly handles file-not-found' do
-        expect { EnvParser.autoregister 'nonexistent filename' }.to raise_error(EnvParser::AutoregisterFileNotFound)
+    it 'properly handles file-not-found' do
+      expect { EnvParser.autoregister 'nonexistent filename' }.to raise_error(EnvParser::AutoregisterFileNotFound)
+    end
+
+    it 'properly handles unparseable YAML' do
+      filename = Tempfile.open('EnvParser.autoregister.') do |file|
+        file.write <<~MALFORMED_YAML.chomp
+          SOME_INT:
+            as:
+            hello
+        MALFORMED_YAML
+
+        file.path
       end
 
-      it 'properly handles unparseable YAML' do
-        filename = Tempfile.open('EnvParser.autoregister.') do |file|
-          file.write <<~MALFORMED_YAML.chomp
-            SOME_INT:
-              as:
-              hello
-          MALFORMED_YAML
-
-          file.path
-        end
-
-        expect { EnvParser.autoregister filename }.to raise_error(EnvParser::UnparseableAutoregisterSpec)
-      end
+      expect { EnvParser.autoregister filename }.to raise_error(EnvParser::UnparseableAutoregisterSpec)
     end
   end
 end


### PR DESCRIPTION
This adds the ability to define constants to be registered via a config file (".env_parser.yml"). Not only does this centralize ENV constant assignment, but it allows for automatic registration of these values if the gem dependency is defined as: `gem 'env_parser', require: 'env_parser/autoregister'`