### PR TITLE
add: support for the "within" option in autoregister YAML

### DIFF
--- a/lib/env_parser.rb
+++ b/lib/env_parser.rb
@@ -251,7 +251,11 @@ class EnvParser
 
       autoregister_spec.deep_symbolize_keys!
       autoregister_spec.transform_values! do |spec|
-        spec.slice(:as, :if_unset, :from_set).merge as: spec[:as]&.to_sym
+        sanitized = spec.slice(:as, :within, :if_unset, :from_set)
+        sanitized[:as] = sanitized[:as].to_sym if sanitized.key? :as
+        sanitized[:within] = sanitized[:within].constantize if sanitized.key? :within
+
+        sanitized
       end
 
       register_all autoregister_spec

--- a/spec/env_parser_spec.rb
+++ b/spec/env_parser_spec.rb
@@ -156,6 +156,10 @@ RSpec.describe EnvParser do
           SOME_STRING:
             as: :string
             if_unset: "unexpected"
+
+          CLASS_CONSTANT:
+            as: :string
+            within: String
         YAML
 
         file.path
@@ -163,10 +167,12 @@ RSpec.describe EnvParser do
 
       ENV['SOME_INT'] = '99'
       ENV['SOME_STRING'] = 'twelve'
+      ENV['CLASS_CONSTANT'] = 'tricky'
       EnvParser.autoregister filename
 
       expect(SOME_INT).to eq(99)
       expect(SOME_STRING).to eq('twelve')
+      expect(String::CLASS_CONSTANT).to eq('tricky')
     end
 
     it 'properly handles file-not-found' do


### PR DESCRIPTION
This adds support for the "within" option in an autoregister YAML file.