### PR TITLE
config: Ruby 3.1 compatibility update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           keys:
           - v1-dependencies-{{ checksum "Gemfile.lock" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+          - v1-dependencies
 
       - run:
           name: update bundler

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# don't commit gem builds
+env_parser-*.gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     env_parser (1.3.2)
-      activesupport (>= 6.1.0)
+      activesupport (>= 6.1.0, < 7.1)
       chronic
       chronic_duration
 
@@ -47,7 +47,7 @@ GEM
     rspec-support (3.12.0)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.40.0)
+    rubocop (1.41.1)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.2.1)

--- a/env_parser.gemspec
+++ b/env_parser.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'env_parser/version'
 
 Gem::Specification.new do |spec|
-  spec.required_ruby_version = '~> 3.0'
+  spec.required_ruby_version = ['>= 3.0', '< 3.2']
 
   spec.name          = 'env_parser'
   spec.version       = EnvParser::VERSION
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.add_dependency 'activesupport', '>= 6.1.0'
+  spec.add_dependency 'activesupport', ['>= 6.1.0', '< 7.1']
   spec.add_dependency 'chronic'
   spec.add_dependency 'chronic_duration'
 


### PR DESCRIPTION
Adds verified compatibility w/ Ruby 3.1 and restricts ActiveSupport to < 7.1 (whose Ruby dependency is not yet known).