### PR TITLE
add: new "version"/"semver" type (under the "internet" types umbrella)

### DIFF
--- a/lib/env_parser/types/internet_types.rb
+++ b/lib/env_parser/types/internet_types.rb
@@ -48,6 +48,18 @@ module EnvParser::Types
   #         Note this does not guarantee RFC5322-conformity.
   #       </td>
   #     </tr>
+  #     <tr>
+  #       <td>:version / :semver</td>
+  #       <td>MatchData</td>
+  #       <td><code>nil</code></td>
+  #       <td>
+  #         The resulting MatchData has named captures for "major", "minor", "patch", "prerelease", and "buildmetadata".
+  #         <br />
+  #         The Regex used for generating this MatchData is available at: https://regex101.com/r/Ly7O1x/3/
+  #         <br />
+  #         See https://semver.org for additional info.
+  #       </td>
+  #     </tr>
   #   </tbody>
   # </table>
   #
@@ -94,6 +106,16 @@ module EnvParser::Types
       raise(EnvParser::ValueNotConvertibleError, 'not an email') unless value.match?(simple_email)
 
       value
+    end
+
+    EnvParser.define_type(:version, aliases: :semver, if_unset: nil) do |value|
+      # We're using the official semver.org-provided regex.
+      semver = %r{^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$} ## rubocop:disable Layout/LineLength
+
+      match_data = value.match(semver)
+      raise(EnvParser::ValueNotConvertibleError, 'not a semver-compliant value') unless match_data
+
+      match_data
     end
   end
 end

--- a/spec/env_parser/types/internet_types_spec.rb
+++ b/spec/env_parser/types/internet_types_spec.rb
@@ -42,4 +42,54 @@ RSpec.describe EnvParser::Types::InternetTypes do
 
     expect { EnvParser.parse('not an email address', as: :email_address) }.to raise_error(EnvParser::ValueNotConvertibleError)
   end
+
+  it 'can parse version numbers' do
+    %i[version semver].each do |type|
+      expect(EnvParser.parse(nil, as: type)).to eq(nil)
+      expect(EnvParser.parse('', as: type)).to eq(nil)
+
+      # Our list of valid version strings is a subset of those in the official semver.org-provided regex suite.
+      # rubocop:disable Layout
+      #
+      valid_version_strings = {
+        '0.0.4'                 => { major: '0' , minor: '0', patch: '4', prerelease: nil           , buildmetadata: nil          },
+        '1.2.3'                 => { major: '1' , minor: '2', patch: '3', prerelease: nil           , buildmetadata: nil          },
+        '1.1.2-prerelease+meta' => { major: '1' , minor: '1', patch: '2', prerelease: 'prerelease'  , buildmetadata: 'meta'       },
+        '1.1.2+meta'            => { major: '1' , minor: '1', patch: '2', prerelease: nil           , buildmetadata: 'meta'       },
+        '1.1.2+meta-valid'      => { major: '1' , minor: '1', patch: '2', prerelease: nil           , buildmetadata: 'meta-valid' },
+        '1.0.0-alpha'           => { major: '1' , minor: '0', patch: '0', prerelease: 'alpha'       , buildmetadata: nil          },
+        '1.0.0-beta'            => { major: '1' , minor: '0', patch: '0', prerelease: 'beta'        , buildmetadata: nil          },
+        '1.0.0-alpha.beta'      => { major: '1' , minor: '0', patch: '0', prerelease: 'alpha.beta'  , buildmetadata: nil          },
+        '1.0.0-alpha.beta.1'    => { major: '1' , minor: '0', patch: '0', prerelease: 'alpha.beta.1', buildmetadata: nil          },
+        '1.0.0-alpha.1'         => { major: '1' , minor: '0', patch: '0', prerelease: 'alpha.1'     , buildmetadata: nil          },
+        '1.0.0-alpha0.valid'    => { major: '1' , minor: '0', patch: '0', prerelease: 'alpha0.valid', buildmetadata: nil          },
+        '1.0.0-alpha.0valid'    => { major: '1' , minor: '0', patch: '0', prerelease: 'alpha.0valid', buildmetadata: nil          },
+        '1.0.0-rc.1+build.1'    => { major: '1' , minor: '0', patch: '0', prerelease: 'rc.1'        , buildmetadata: 'build.1'    },
+        '2.0.0-rc.1+build.123'  => { major: '2' , minor: '0', patch: '0', prerelease: 'rc.1'        , buildmetadata: 'build.123'  },
+        '1.2.3-beta'            => { major: '1' , minor: '2', patch: '3', prerelease: 'beta'        , buildmetadata: nil          },
+        '10.2.3-DEV-SNAPSHOT'   => { major: '10', minor: '2', patch: '3', prerelease: 'DEV-SNAPSHOT', buildmetadata: nil          },
+        '1.2.3-SNAPSHOT-123'    => { major: '1' , minor: '2', patch: '3', prerelease: 'SNAPSHOT-123', buildmetadata: nil          },
+        '2.0.0+build.1848'      => { major: '2' , minor: '0', patch: '0', prerelease: nil           , buildmetadata: 'build.1848' },
+        '2.0.1-alpha.1227'      => { major: '2' , minor: '0', patch: '1', prerelease: 'alpha.1227'  , buildmetadata: nil          },
+        '1.0.0-alpha+beta'      => { major: '1' , minor: '0', patch: '0', prerelease: 'alpha'       , buildmetadata: 'beta'       },
+        '1.0.0-0A.is.legal'     => { major: '1' , minor: '0', patch: '0', prerelease: '0A.is.legal' , buildmetadata: nil          }
+      }
+      # rubocop:enable Layout
+
+      valid_version_strings.each do |version, expected_matches|
+        parsed_value = EnvParser.parse(version, as: type)
+
+        expect(parsed_value).to_not eq(nil)
+        expected_matches.each { |match_name, expected_value| expect(parsed_value[match_name]).to eq(expected_value) }
+      end
+
+      # Our list of invalid version strings is a subset of those in the official semver.org-provided regex suite.
+      #
+      invalid_version_strings = ['1', '1.2', '1.2.3-0123', '1.2.3-0123.0123', '1.1.2+.123', '+invalid', '-invalid', '-invalid+invalid',
+                                 '-invalid.01', 'alpha', 'alpha.1', 'alpha+beta', '1.0.0-alpha..', '1.0.0-alpha..1', '01.1.1', '1.01.1',
+                                 '1.1.01', '1.2.3.DEV', '1.2-SNAPSHOT', '+justmeta', '9.8.7+meta+meta', '9.8.7-whatever+meta+meta']
+
+      invalid_version_strings.each { |version| expect { EnvParser.parse(version, as: type) }.to raise_error(EnvParser::ValueNotConvertibleError) }
+    end
+  end
 end


### PR DESCRIPTION
Adds a new "version" type (also aliased as "semver"), under the umbrella of "internet" types.

Tests that the given string conforms to the official SemVer structure (as defined at [semver.org](https://semver.org/)) and returns a `MatchData` instance for the given source string. This instance then provides convenience named captures for "major", "minor", "patch", "prerelease", and "buildmetadata", as captured via the official semver.org-provided regex.

Closes #28.